### PR TITLE
perf: replace random seed by random state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+v2.0.2 - 2022-09-21
+----------------------
+
+Fix:
+
+* [#48](https://github.com/godaddy/sample-size/pull/48) - Add random state parameters to have all simulation functions generating fixed output given a fixed input
+
+
 v2.0.1 - 2022-08-15
 ----------------------
 

--- a/sample_size/metrics.py
+++ b/sample_size/metrics.py
@@ -8,7 +8,7 @@ from scipy import stats
 from statsmodels.stats.power import NormalIndPower
 from statsmodels.stats.power import TTestIndPower
 
-RANDOM_SEED = 1
+RANDOM_SEED = np.random.RandomState(1)
 
 
 class BaseMetric:

--- a/sample_size/metrics.py
+++ b/sample_size/metrics.py
@@ -8,7 +8,7 @@ from scipy import stats
 from statsmodels.stats.power import NormalIndPower
 from statsmodels.stats.power import TTestIndPower
 
-RANDOM_SEED = np.random.RandomState(1)
+RANDOM_STATE = np.random.RandomState(1)
 
 
 class BaseMetric:
@@ -55,7 +55,7 @@ class BaseMetric:
 
         p_values = np.empty(true_alt.shape)
         p_values[true_alt] = self._generate_alt_p_values(total_alt, sample_size)
-        p_values[~true_alt] = stats.uniform.rvs(0, 1, total_null, random_state=RANDOM_SEED)
+        p_values[~true_alt] = stats.uniform.rvs(0, 1, total_null, random_state=RANDOM_STATE)
 
         return p_values
 
@@ -93,7 +93,7 @@ class BooleanMetric(BaseMetric):
 
     def _generate_alt_p_values(self, size: int, sample_size: int) -> npt.NDArray[np.float_]:
         effect_size = self.mde / np.sqrt(2 * self.variance / sample_size)
-        z_alt = stats.norm.rvs(loc=effect_size, size=size, random_state=RANDOM_SEED)
+        z_alt = stats.norm.rvs(loc=effect_size, size=size, random_state=RANDOM_STATE)
         p_values: npt.NDArray[np.float_] = 2 * stats.norm.sf(np.abs(z_alt))
         return p_values
 
@@ -119,7 +119,7 @@ class NumericMetric(BaseMetric):
 
     def _generate_alt_p_values(self, size: int, sample_size: int) -> npt.NDArray[np.float_]:
         nc = np.sqrt(sample_size / 2 / self.variance) * self.mde
-        t_alt = stats.nct.rvs(nc=nc, df=2 * (sample_size - 1), size=size, random_state=RANDOM_SEED)
+        t_alt = stats.nct.rvs(nc=nc, df=2 * (sample_size - 1), size=size, random_state=RANDOM_STATE)
         p_values: npt.NDArray[np.float_] = 2 * stats.t.sf(np.abs(t_alt), 2 * (sample_size - 1))
         return p_values
 
@@ -164,6 +164,6 @@ class RatioMetric(BaseMetric):
 
     def _generate_alt_p_values(self, size: int, sample_size: int) -> npt.NDArray[np.float_]:
         effect_size = self.mde / np.sqrt(2 * self.variance / sample_size)
-        z_alt = stats.norm.rvs(loc=effect_size, size=size, random_state=RANDOM_SEED)
+        z_alt = stats.norm.rvs(loc=effect_size, size=size, random_state=RANDOM_STATE)
         p_values: npt.NDArray[np.float_] = 2 * stats.norm.sf(np.abs(z_alt))
         return p_values

--- a/sample_size/multiple_testing.py
+++ b/sample_size/multiple_testing.py
@@ -2,7 +2,6 @@ from typing import List
 
 import numpy as np
 import numpy.typing as npt
-from numpy.random import RandomState
 from statsmodels.stats.multitest import multipletests
 
 from sample_size.metrics import RANDOM_SEED
@@ -95,9 +94,7 @@ class MultipleTestingMixin:
             return rejected
 
         for num_true_alt in range(1, len(metrics) + 1):
-            true_alt = np.array(
-                [RandomState(RANDOM_SEED).permutation(len(metrics)) < num_true_alt for _ in range(replication)]
-            ).T
+            true_alt = np.array([RANDOM_SEED.permutation(len(metrics)) < num_true_alt for _ in range(replication)]).T
             p_values = []
             for i, m in enumerate(metrics):
                 p_values.append(m.generate_p_values(true_alt[i], sample_size))

--- a/sample_size/multiple_testing.py
+++ b/sample_size/multiple_testing.py
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.typing as npt
 from statsmodels.stats.multitest import multipletests
 
-from sample_size.metrics import RANDOM_SEED
+from sample_size.metrics import RANDOM_STATE
 from sample_size.metrics import BaseMetric
 
 DEFAULT_REPLICATION: int = 400
@@ -94,7 +94,7 @@ class MultipleTestingMixin:
             return rejected
 
         for num_true_alt in range(1, len(metrics) + 1):
-            true_alt = np.array([RANDOM_SEED.permutation(len(metrics)) < num_true_alt for _ in range(replication)]).T
+            true_alt = np.array([RANDOM_STATE.permutation(len(metrics)) < num_true_alt for _ in range(replication)]).T
             p_values = []
             for i, m in enumerate(metrics):
                 p_values.append(m.generate_p_values(true_alt[i], sample_size))

--- a/tests/sample_size/test_metrics.py
+++ b/tests/sample_size/test_metrics.py
@@ -10,7 +10,7 @@ from parameterized import parameterized
 from statsmodels.stats.power import NormalIndPower
 from statsmodels.stats.power import TTestIndPower
 
-from sample_size.metrics import RANDOM_SEED
+from sample_size.metrics import RANDOM_STATE
 from sample_size.metrics import BaseMetric
 from sample_size.metrics import BooleanMetric
 from sample_size.metrics import NumericMetric
@@ -129,7 +129,7 @@ class BooleanMetricTestCase(unittest.TestCase):
         p = metric._generate_alt_p_values(size, sample_size)
 
         effect_sample_size = self.DEFAULT_MDE / np.sqrt(2 * self.DEFAULT_MOCK_VARIANCE / sample_size)
-        mock_norm.rvs.assert_called_once_with(loc=effect_sample_size, size=size, random_state=RANDOM_SEED)
+        mock_norm.rvs.assert_called_once_with(loc=effect_sample_size, size=size, random_state=RANDOM_STATE)
         mock_norm.sf.assert_called_once_with(np.abs(mock_norm.rvs.return_value))
         assert_array_equal(p, p_values)
 
@@ -162,7 +162,7 @@ class NumericMetricTestCase(unittest.TestCase):
 
         effect_sample_size = np.sqrt(sample_size / 2 / self.DEFAULT_VARIANCE) * self.DEFAULT_MDE
         df = 2 * (sample_size - 1)
-        mock_nct.rvs.assert_called_once_with(nc=effect_sample_size, df=df, size=size, random_state=RANDOM_SEED)
+        mock_nct.rvs.assert_called_once_with(nc=effect_sample_size, df=df, size=size, random_state=RANDOM_STATE)
         mock_t.sf.assert_called_once_with(np.abs(mock_nct.rvs.return_value), df)
         assert_array_equal(p, p_values)
 
@@ -232,6 +232,6 @@ class RatioMetricTestCase(unittest.TestCase):
         p = metric._generate_alt_p_values(size, sample_size)
 
         effect_sample_size = self.DEFAULT_MDE / np.sqrt(2 * self.DEFAULT_VARIANCE / sample_size)
-        mock_norm.rvs.assert_called_once_with(loc=effect_sample_size, size=size, random_state=RANDOM_SEED)
+        mock_norm.rvs.assert_called_once_with(loc=effect_sample_size, size=size, random_state=RANDOM_STATE)
         mock_norm.sf.assert_called_once_with(np.abs(mock_norm.rvs.return_value))
         assert_array_equal(p, p_values)

--- a/tests/sample_size/test_multiple_testing.py
+++ b/tests/sample_size/test_multiple_testing.py
@@ -112,16 +112,16 @@ class MultipleTestingTestCase(unittest.TestCase):
 
     @parameterized.expand(
         [
-            (TEST_BOOLEAN, 2002, np.random.RandomState(1)),
-            (TEST_NUMERIC, 3455, np.random.RandomState(2)),
-            (TEST_RATIO, 22115, np.random.RandomState(3)),
-            (TEST_BOOLEAN, 2051, np.random.RandomState(7)),
-            (TEST_NUMERIC, 3433, np.random.RandomState(8)),
-            (TEST_RATIO, 20583, np.random.RandomState(6)),
+            (TEST_BOOLEAN, 2002, 1),
+            (TEST_NUMERIC, 3455, 2),
+            (TEST_RATIO, 22115, 3),
+            (TEST_BOOLEAN, 2051, 7),
+            (TEST_NUMERIC, 3433, 8),
+            (TEST_RATIO, 20583, 6),
         ]
     )
     def test_get_multiple_sample_size_fixed_output(self, test_metric, test_sample_size, seed):
-        with patch("sample_size.metrics.RANDOM_SEED", seed):
+        with patch("sample_size.metrics.RANDOM_STATE", np.random.RandomState(seed)):
             calculator = SampleSizeCalculator()
             calculator.register_metrics([test_metric] * 2)
             sample_size = calculator.get_sample_size()

--- a/tests/sample_size/test_multiple_testing.py
+++ b/tests/sample_size/test_multiple_testing.py
@@ -112,12 +112,12 @@ class MultipleTestingTestCase(unittest.TestCase):
 
     @parameterized.expand(
         [
-            (TEST_BOOLEAN, 1908, 1),
-            (TEST_NUMERIC, 3455, 2),
-            (TEST_RATIO, 21593, 3),
-            (TEST_BOOLEAN, 2051, 7),
-            (TEST_NUMERIC, 3215, 5),
-            (TEST_RATIO, 20096, 6),
+            (TEST_BOOLEAN, 2002, np.random.RandomState(1)),
+            (TEST_NUMERIC, 3455, np.random.RandomState(2)),
+            (TEST_RATIO, 22115, np.random.RandomState(3)),
+            (TEST_BOOLEAN, 2051, np.random.RandomState(7)),
+            (TEST_NUMERIC, 3433, np.random.RandomState(8)),
+            (TEST_RATIO, 20583, np.random.RandomState(6)),
         ]
     )
     def test_get_multiple_sample_size_fixed_output(self, test_metric, test_sample_size, seed):


### PR DESCRIPTION
random_state parameter is changed to `RandomState` from an integer in order to reduce the runtime

[ML-5850](https://jira.godaddy.com/browse/ML-5850)

[the reason of runtime spike](https://godaddy.enterprise.slack.com/files/U01MNK44Y2D/F043Q88FAAE/screen_shot_2022-09-23_at_11.53.13.png)

To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] A full explanation here in the PR description of the work done and statistical methods used

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [ ] Yes (backward compatible)
* [ ] No (breaking changes)
