### PR TITLE
feat(guardrail): add one-sided input and calculation for single comparison

### DIFF
--- a/sample_size/metrics.py
+++ b/sample_size/metrics.py
@@ -15,8 +15,9 @@ class BaseMetric:
     __metaclass__ = ABCMeta
     mde: float
 
-    def __init__(self, mde: float):
+    def __init__(self, mde: float, alternative: str):
         self.mde = mde
+        self.alternative = alternative
 
     @property
     @abstractmethod
@@ -72,8 +73,9 @@ class BooleanMetric(BaseMetric):
         self,
         probability: float,
         mde: float,
+        alternative: str,
     ):
-        super(BooleanMetric, self).__init__(mde)
+        super(BooleanMetric, self).__init__(mde, alternative)
         self.probability = self._check_probability(probability)
 
     @property
@@ -105,8 +107,9 @@ class NumericMetric(BaseMetric):
         self,
         variance: float,
         mde: float,
+        alternative: str,
     ):
-        super(NumericMetric, self).__init__(mde)
+        super(NumericMetric, self).__init__(mde, alternative)
         self._variance = self.check_positive(variance, "variance")
 
     @property
@@ -139,8 +142,9 @@ class RatioMetric(BaseMetric):
         denominator_variance: float,
         covariance: float,
         mde: float,
+        alternative: str,
     ):
-        super(RatioMetric, self).__init__(mde)
+        super(RatioMetric, self).__init__(mde, alternative)
         # TODO: add check for Cauchy-Schwarz inequality
         self.numerator_mean = numerator_mean
         self.numerator_variance = self.check_positive(numerator_variance, "numerator variance")

--- a/sample_size/metrics_schema.json
+++ b/sample_size/metrics_schema.json
@@ -20,6 +20,7 @@
                         "metric_metadata": {
                             "type": "object",
                             "properties": {
+                                "alternative": {"type": "string"},
                                 "mde": {"type": "number"},
                                 "probability": {"type": "number"}
                             },
@@ -39,6 +40,7 @@
                         "metric_metadata": {
                             "type": "object",
                             "properties": {
+                                "alternative": {"type": "string"},
                                 "mde": {"type": "number"},
                                 "variance": {"type": "number"}
                             },
@@ -58,6 +60,7 @@
                         "metric_metadata": {
                             "type": "object",
                             "properties": {
+                                "alternative": {"type": "string"},
                                 "mde": {"type": "number"},
                                 "numerator_mean": {"type": "number"},
                                 "numerator_variance": {"type": "number"},

--- a/sample_size/sample_size_calculator.py
+++ b/sample_size/sample_size_calculator.py
@@ -47,7 +47,7 @@ class SampleSizeCalculator(MultipleTestingMixin):
                 alpha=alpha,
                 power=self.power,
                 ratio=1,
-                alternative="two-sided",
+                alternative=metric.alternative,
             )
         )
         return sample_size

--- a/sample_size/scripts/input_utils.py
+++ b/sample_size/scripts/input_utils.py
@@ -1,3 +1,4 @@
+from typing import Any
 from typing import Collection
 from typing import Dict
 from typing import List
@@ -61,6 +62,24 @@ def get_mde(metric_type: str) -> float:
     return mde
 
 
+def get_alternative() -> str:
+    alternative = (
+        input(
+            "Enter the alternative hypothesis type (two-sided, larger, smaller) or press Enter to use "
+            "default two-sided test: "
+        )
+        .strip()
+        .lower()
+    )
+    if alternative in ["two-sided", "larger", "smaller"]:
+        return alternative
+    elif alternative == "":
+        print("Using default(two-sided test)...")
+        return "two-sided"
+    else:
+        raise ValueError("Error: Unexpected alternative type. Please enter two-sided, larger, or smaller.")
+
+
 def get_metric_type() -> str:
     metric_type = input("Enter metric type (Boolean, Numeric, Ratio): ").strip().lower()
     if metric_type in ["boolean", "numeric", "ratio"]:
@@ -69,7 +88,7 @@ def get_metric_type() -> str:
         raise ValueError("Error: Unexpected metric type. Please enter Boolean, Numeric, or Ratio.")
 
 
-def get_metric_parameters(parameter_definitions: Dict[str, str]) -> Dict[str, float]:
+def get_metric_parameters(parameter_definitions: Dict[str, str]) -> Dict[str, Any]:
     parameters = {}
 
     for parameter_name, parameter_definition in parameter_definitions.items():
@@ -113,6 +132,7 @@ def _get_metric() -> Dict[str, Collection[str]]:
     metric_type = get_metric_type()
     metric_metadata = get_metric_parameters(METRIC_PARAMETERS[metric_type])
     metric_metadata["mde"] = get_mde(metric_type)
+    metric_metadata["alternative"] = get_alternative()
     return {"metric_type": metric_type, "metric_metadata": metric_metadata}
 
 

--- a/sample_size/scripts/input_utils.py
+++ b/sample_size/scripts/input_utils.py
@@ -133,7 +133,7 @@ def _get_metric() -> Dict[str, Collection[str]]:
     metric_metadata = get_metric_parameters(METRIC_PARAMETERS[metric_type])
     metric_metadata["mde"] = get_mde(metric_type)
     if get_alternative() == "two-sided":
-        metric_metadata["alternative"] = get_alternative()
+        metric_metadata["alternative"] = "two-sided"
     else:
         metric_metadata["alternative"] = "larger" if metric_metadata["mde"] > 0 else "smaller"
     return {"metric_type": metric_type, "metric_metadata": metric_metadata}

--- a/sample_size/scripts/input_utils.py
+++ b/sample_size/scripts/input_utils.py
@@ -65,13 +65,13 @@ def get_mde(metric_type: str) -> float:
 def get_alternative() -> str:
     alternative = (
         input(
-            "Enter the alternative hypothesis type (two-sided, larger, smaller) or press Enter to use "
+            "Enter the alternative hypothesis type (two-sided, one-sided) or press Enter to use "
             "default two-sided test: "
         )
         .strip()
         .lower()
     )
-    if alternative in ["two-sided", "larger", "smaller"]:
+    if alternative in ["two-sided", "one-sided"]:
         return alternative
     elif alternative == "":
         print("Using default(two-sided test)...")
@@ -132,7 +132,10 @@ def _get_metric() -> Dict[str, Collection[str]]:
     metric_type = get_metric_type()
     metric_metadata = get_metric_parameters(METRIC_PARAMETERS[metric_type])
     metric_metadata["mde"] = get_mde(metric_type)
-    metric_metadata["alternative"] = get_alternative()
+    if get_alternative() == "two-sided":
+        metric_metadata["alternative"] = get_alternative()
+    else:
+        metric_metadata["alternative"] = "larger" if metric_metadata["mde"] > 0 else "smaller"
     return {"metric_type": metric_type, "metric_metadata": metric_metadata}
 
 

--- a/tests/sample_size/scripts/test_input_utils.py
+++ b/tests/sample_size/scripts/test_input_utils.py
@@ -331,8 +331,8 @@ class UtilsTestCase(unittest.TestCase):
 
     @parameterized.expand(
         [
-            ("boolean", {"probability": 0.05}),
-            ("numeric", {"variance": 500}),
+            ("boolean", {"probability": 0.05}, 0.05, "one-sided", "larger"),
+            ("numeric", {"variance": 500}, -0.5, "one-sided", "smaller"),
             (
                 "ratio",
                 {
@@ -342,6 +342,9 @@ class UtilsTestCase(unittest.TestCase):
                     "denominator_variance": 2000,
                     "covariance": 5000,
                 },
+                1,
+                "two-sided",
+                "two-sided",
             ),
         ]
     )
@@ -353,19 +356,21 @@ class UtilsTestCase(unittest.TestCase):
         self,
         test_metric_type,
         test_metric_metadata,
+        test_mde,
+        test_alternative,
+        expected_alternative,
         mock_get_metric_type,
         mock_get_metric_parameters,
         mock_get_mde,
         mock_alternative,
     ):
-        test_mde = 0.05
-        test_alternative = "two-sided"
         mock_get_metric_type.return_value = test_metric_type
         mock_get_metric_parameters.return_value = test_metric_metadata
         mock_get_mde.return_value = test_mde
         mock_alternative.return_value = test_alternative
 
         metric = input_utils._get_metric()
+        test_metric_metadata["alternative"] = expected_alternative
         self.assertEqual(
             metric,
             {"metric_type": test_metric_type, "metric_metadata": test_metric_metadata},
@@ -373,6 +378,7 @@ class UtilsTestCase(unittest.TestCase):
         mock_get_metric_type.assert_called_once()
         mock_get_metric_parameters.assert_called_once_with(input_utils.METRIC_PARAMETERS[test_metric_type])
         mock_get_mde.assert_called_once_with(test_metric_type)
+        mock_alternative.assert_called_once()
 
     @patch("sample_size.scripts.input_utils.register_another_metric")
     @patch("sample_size.scripts.input_utils._get_metric")

--- a/tests/sample_size/scripts/test_input_utils.py
+++ b/tests/sample_size/scripts/test_input_utils.py
@@ -135,7 +135,7 @@ class UtilsTestCase(unittest.TestCase):
         )
         mock_get_float.assert_called_once_with(test_mde, "minimum detectable effect")
 
-    @parameterized.expand([("Larger", "larger"), ("SMALLER", "smaller"), ("two-sided", "two-sided"), ("", "two-sided")])
+    @parameterized.expand([("One-Sided", "one-sided"), ("two-sided", "two-sided"), ("", "two-sided")])
     @patch("sample_size.scripts.input_utils.input")
     def test_get_alternative(self, test_alternative, expected_alternative, mock_input):
         mock_input.return_value = test_alternative

--- a/tests/sample_size/test_metrics.py
+++ b/tests/sample_size/test_metrics.py
@@ -16,6 +16,8 @@ from sample_size.metrics import BooleanMetric
 from sample_size.metrics import NumericMetric
 from sample_size.metrics import RatioMetric
 
+ALTERNATIVE = "two-sided"
+
 
 class DummyMetric(BaseMetric):
     def power_analysis_instance(self):
@@ -54,7 +56,7 @@ class BaseMetricTestCase(unittest.TestCase):
         mock_alt_p_values.side_effect = lambda size, __: np.array([alt_p_value] * size)
         mock_stats.uniform.rvs.side_effect = lambda _, __, size, random_state: np.array([null_p_value] * size)
 
-        metric = DummyMetric(mde)
+        metric = DummyMetric(mde, ALTERNATIVE)
 
         p_values = metric.generate_p_values(true_alt, sample_size)
 
@@ -66,6 +68,7 @@ class BaseMetricTestCase(unittest.TestCase):
 
 class BooleanMetricTestCase(unittest.TestCase):
     def setUp(self):
+        self.ALTERNATIVE = "two-sided"
         self.DEFAULT_MDE = 0.01
         self.DEFAULT_PROBABILITY = 0.05
         self.DEFAULT_MOCK_VARIANCE = 99
@@ -75,7 +78,7 @@ class BooleanMetricTestCase(unittest.TestCase):
     def test_boolean_metric_constructor_sets_params(self, mock_variance, mock_check_probability):
         mock_variance.__get__ = MagicMock(return_value=self.DEFAULT_MOCK_VARIANCE)
         mock_check_probability.return_value = self.DEFAULT_PROBABILITY
-        boolean = BooleanMetric(self.DEFAULT_PROBABILITY, self.DEFAULT_MDE)
+        boolean = BooleanMetric(self.DEFAULT_PROBABILITY, self.DEFAULT_MDE, ALTERNATIVE)
 
         mock_check_probability.assert_called_once_with(self.DEFAULT_PROBABILITY)
         self.assertEqual(boolean.probability, self.DEFAULT_PROBABILITY)
@@ -84,7 +87,7 @@ class BooleanMetricTestCase(unittest.TestCase):
         self.assertIsInstance(boolean.power_analysis_instance, NormalIndPower)
 
     def test_boolean_metric_variance(self):
-        boolean = BooleanMetric(self.DEFAULT_PROBABILITY, self.DEFAULT_MDE)
+        boolean = BooleanMetric(self.DEFAULT_PROBABILITY, self.DEFAULT_MDE, ALTERNATIVE)
 
         self.assertEqual(boolean.variance, 0.0475)
 
@@ -125,7 +128,7 @@ class BooleanMetricTestCase(unittest.TestCase):
         p_value_generator.return_value = p_values
         mock_variance.__get__ = MagicMock(return_value=self.DEFAULT_MOCK_VARIANCE)
 
-        metric = BooleanMetric(self.DEFAULT_PROBABILITY, self.DEFAULT_MDE)
+        metric = BooleanMetric(self.DEFAULT_PROBABILITY, self.DEFAULT_MDE, ALTERNATIVE)
         p = metric._generate_alt_p_values(size, sample_size)
 
         effect_sample_size = self.DEFAULT_MDE / np.sqrt(2 * self.DEFAULT_MOCK_VARIANCE / sample_size)
@@ -140,7 +143,7 @@ class NumericMetricTestCase(unittest.TestCase):
         self.DEFAULT_VARIANCE = 5000
 
     def test_numeric_metric_constructor_sets_params(self):
-        numeric = NumericMetric(self.DEFAULT_VARIANCE, self.DEFAULT_MDE)
+        numeric = NumericMetric(self.DEFAULT_VARIANCE, self.DEFAULT_MDE, ALTERNATIVE)
 
         self.assertEqual(numeric.variance, self.DEFAULT_VARIANCE)
         self.assertEqual(numeric.mde, self.DEFAULT_MDE)
@@ -157,7 +160,7 @@ class NumericMetricTestCase(unittest.TestCase):
         p_value_generator.return_value = p_values
         mock_variance.__get__ = MagicMock(return_value=self.DEFAULT_VARIANCE)
 
-        metric = NumericMetric(self.DEFAULT_VARIANCE, self.DEFAULT_MDE)
+        metric = NumericMetric(self.DEFAULT_VARIANCE, self.DEFAULT_MDE, ALTERNATIVE)
         p = metric._generate_alt_p_values(size, sample_size)
 
         effect_sample_size = np.sqrt(sample_size / 2 / self.DEFAULT_VARIANCE) * self.DEFAULT_MDE
@@ -187,6 +190,7 @@ class RatioMetricTestCase(unittest.TestCase):
             self.DEFAULT_DENOMINATOR_VARIANCE,
             self.DEFAULT_COVARIANCE,
             self.DEFAULT_MDE,
+            ALTERNATIVE,
         )
 
         self.assertEqual(ratio.numerator_mean, self.DEFAULT_NUMERATOR_MEAN)
@@ -206,6 +210,7 @@ class RatioMetricTestCase(unittest.TestCase):
             self.DEFAULT_DENOMINATOR_VARIANCE,
             self.DEFAULT_COVARIANCE,
             self.DEFAULT_MDE,
+            ALTERNATIVE,
         )
 
         self.assertEqual(ratio.variance, 5.0)
@@ -227,6 +232,7 @@ class RatioMetricTestCase(unittest.TestCase):
             self.DEFAULT_DENOMINATOR_VARIANCE,
             self.DEFAULT_COVARIANCE,
             self.DEFAULT_MDE,
+            ALTERNATIVE,
         )
 
         p = metric._generate_alt_p_values(size, sample_size)

--- a/tests/sample_size/test_multiple_testing.py
+++ b/tests/sample_size/test_multiple_testing.py
@@ -11,9 +11,13 @@ from sample_size.multiple_testing import DEFAULT_REPLICATION
 from sample_size.sample_size_calculator import DEFAULT_ALPHA
 from sample_size.sample_size_calculator import DEFAULT_POWER
 from sample_size.sample_size_calculator import SampleSizeCalculator
+from tests.sample_size.test_metrics import ALTERNATIVE
 
-TEST_BOOLEAN = {"metric_type": "boolean", "metric_metadata": {"probability": 0.05, "mde": 0.02}}
-TEST_NUMERIC = {"metric_type": "numeric", "metric_metadata": {"variance": 5000, "mde": 5}}
+TEST_BOOLEAN = {
+    "metric_type": "boolean",
+    "metric_metadata": {"probability": 0.05, "mde": 0.02, "alternative": ALTERNATIVE},
+}
+TEST_NUMERIC = {"metric_type": "numeric", "metric_metadata": {"variance": 5000, "mde": 5, "alternative": ALTERNATIVE}}
 TEST_RATIO = {
     "metric_type": "ratio",
     "metric_metadata": {
@@ -23,6 +27,7 @@ TEST_RATIO = {
         "denominator_variance": 2000,
         "covariance": 25000,
         "mde": 1,
+        "alternative": ALTERNATIVE,
     },
 }
 
@@ -34,7 +39,12 @@ class MultipleTestingTestCase(unittest.TestCase):
         self.test_metric_type = "boolean"
         self.test_probability = 0.05
         self.test_mde = 0.02
-        self.test_metric_metadata = {"probability": self.test_probability, "mde": self.test_mde}
+        self.test_alternative = ALTERNATIVE
+        self.test_metric_metadata = {
+            "probability": self.test_probability,
+            "mde": self.test_mde,
+            "alternative": self.test_alternative,
+        }
         self.test_metric = {"metric_type": self.test_metric_type, "metric_metadata": self.test_metric_metadata}
 
     @parameterized.expand([(0,), (1,), (DEFAULT_POWER + 3 * DEFAULT_EPSILON,)])

--- a/tests/sample_size/test_sample_size_calculator.py
+++ b/tests/sample_size/test_sample_size_calculator.py
@@ -11,6 +11,7 @@ from sample_size.sample_size_calculator import DEFAULT_ALPHA
 from sample_size.sample_size_calculator import DEFAULT_POWER
 from sample_size.sample_size_calculator import DEFAULT_VARIANTS
 from sample_size.sample_size_calculator import SampleSizeCalculator
+from tests.sample_size.test_metrics import ALTERNATIVE
 
 
 class SampleSizeCalculatorTestCase(unittest.TestCase):
@@ -44,6 +45,7 @@ class SampleSizeCalculatorTestCase(unittest.TestCase):
         test_metric = BooleanMetric(
             test_probability,
             test_mde,
+            ALTERNATIVE,
         )
         mock_solve_power.return_value = test_sample_size
 
@@ -67,6 +69,7 @@ class SampleSizeCalculatorTestCase(unittest.TestCase):
         test_metric = NumericMetric(
             test_variance,
             test_mde,
+            ALTERNATIVE,
         )
         mock_solve_power.return_value = test_sample_size
         calculator = SampleSizeCalculator()
@@ -84,8 +87,8 @@ class SampleSizeCalculatorTestCase(unittest.TestCase):
 
     @parameterized.expand(
         [
-            ("boolean", {"probability": 0.05, "mde": 0.02}),
-            ("numeric", {"variance": 500, "mde": 5}),
+            ("boolean", {"probability": 0.05, "mde": 0.02, "alternative": "two-sided"}),
+            ("numeric", {"variance": 500, "mde": 5, "alternative": "smaller"}),
             (
                 "ratio",
                 {
@@ -95,6 +98,7 @@ class SampleSizeCalculatorTestCase(unittest.TestCase):
                     "denominator_variance": 2000,
                     "covariance": 5000,
                     "mde": 10,
+                    "alternative": "larger",
                 },
             ),
         ]
@@ -128,7 +132,7 @@ class SampleSizeCalculatorTestCase(unittest.TestCase):
         test_sample_size = 2000
         mock_get_multiple_sample_size.return_value = test_sample_size
         mock_get_single_sample_size.return_value = test_sample_size
-        test_metric_metadata = {"probability": 0.05, "mde": 0.02}
+        test_metric_metadata = {"probability": 0.05, "mde": 0.02, "alternative": "two-sided"}
         calculator = SampleSizeCalculator()
         calculator.register_metrics(
             [
@@ -156,7 +160,7 @@ class SampleSizeCalculatorTestCase(unittest.TestCase):
         test_metric_type = "boolean"
         test_probability = 0.05
         test_mde = 0.02
-        test_metric_metadata = {"probability": test_probability, "mde": test_mde}
+        test_metric_metadata = {"probability": test_probability, "mde": test_mde, "alternative": "larger"}
 
         calculator = SampleSizeCalculator()
         calculator.register_metrics([{"metric_type": test_metric_type, "metric_metadata": test_metric_metadata}])
@@ -172,7 +176,7 @@ class SampleSizeCalculatorTestCase(unittest.TestCase):
         test_metric_type = "numeric"
         test_variance = 5000.0
         test_mde = 5.0
-        test_metric_metadata = {"variance": test_variance, "mde": test_mde}
+        test_metric_metadata = {"variance": test_variance, "mde": test_mde, "alternative": "two-sided"}
 
         calculator = SampleSizeCalculator()
         calculator.register_metrics([{"metric_type": test_metric_type, "metric_metadata": test_metric_metadata}])
@@ -200,6 +204,7 @@ class SampleSizeCalculatorTestCase(unittest.TestCase):
             "denominator_variance": test_denominator_variance,
             "covariance": test_covariance,
             "mde": test_mde,
+            "alternative": "smaller",
         }
 
         calculator = SampleSizeCalculator()


### PR DESCRIPTION
The task [ML-5831](https://jira.godaddy.com/browse/ML-5831) has been split to 2 parts, and this PR is the first part.

Changes:
1. Add a question for alternative hypothesis in `sample_size/scripts/input_utils.py`
2. Add attribute `alternative` to each metric class's `__init__` in `sample_size/metrics.py`
3. Add `alternative` to `sample_size/metrics_schema.json`
4. Change `solve_power`'s alternative argument to the alternative input we got from change (1.) in `sample_size/sample_size_calculator.py`
5. Update corresponding unit tests

Upcoming changes in next PR:
1. Add one-sided test's simulation and calculation to `multiple_testing` module
2. Update unit tests; may replace 'two-sided' in existing test cases by one-sided test cases

To help us get this pull request reviewed and merged quickly, please be sure to include the following items:

* [ ] Tests (if applicable)
* [ ] Documentation (if applicable)
* [ ] A full explanation here in the PR description of the work done and statistical methods used

## PR Type
What kind of change does this PR introduce?

* [ ] Bugfix
* [ ] Feature
* [ ] Code style update (formatting, local variables)
* [ ] Refactoring (no functional changes, no api changes)
* [ ] Build related changes
* [ ] CI related changes
* [ ] Documentation content changes
* [ ] Tests
* [ ] Other

## Backward Compatibility

Is this change backward compatible with the most recently released version? Does it introduce changes which might change the user experience in any way? Does it alter the API in any way?

* [ ] Yes (backward compatible)
* [ ] No (breaking changes)
